### PR TITLE
Allow for plants to return one of multiple ingredients

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,3 +23,22 @@ You can find the configuration file in `data/custom/__config_VisualHarvesting.js
     }
 }
 ```
+A plant may contain more than one ingredient.  To do so, substitute the `ingredient` string with a table of strings called `ingredients` as seen below:
+```
+"<container refId>": {
+    "ingredients": {
+        "<ingredient refId>",
+        "<ingredient refId>"
+    },
+    "amount": {
+        "0": <highest roll that gives 0 ingredients>",
+        "1": <highest roll that gives 1 ingredients>",
+        ...
+    }
+}
+```
+When successfully harvested, one of the listed ingredients is randomly selected and placed in the player's inventory.
+
+### Mod Support
+
+You can find a config file with all plants from [Province Cyrodiil](https://www.nexusmods.com/morrowind/mods/44922), [Skyrim Home of the Nords](https://www.nexusmods.com/morrowind/mods/44921), and [Tamriel Rebuilt](https://www.tamriel-rebuilt.org/downloads/main-release) at [this link](https://git.modding-openmw.com/TES3MP/tes3mp-CoreScripts/raw/branch/0.7.0-momw-modded/data/custom/__config_VisualHarvesting.json).  Simply place this version of the VisualHarvesting config file into your `data/custom/` folder, or copy the `plants` table out and adjust to suit your needs.

--- a/main.lua
+++ b/main.lua
@@ -71,15 +71,21 @@ function VisualHarvesting.addIngredientToPlayer(pid, refId)
         tes3mp.MessageBox(pid, VisualHarvesting.config.menuId, VisualHarvesting.config.fail.message)
         tes3mp.PlaySpeech(pid, VisualHarvesting.config.fail.sound)
     else
-        inventoryHelper.addItem(player.data.inventory, plantConfig.ingredient, ingredient_count, -1, -1, "")
-        
+        local ingred
+        if plantConfig.ingredient == nil then
+            ingred = plantConfig.ingredients[math.random(#plantConfig.ingredients)]
+        else
+            ingred = plantConfig.ingredient
+        end
+
+        inventoryHelper.addItem(player.data.inventory, ingred, ingredient_count, -1, -1, "")
         local message = string.format(VisualHarvesting.config.success.message, ingredient_count)
         tes3mp.MessageBox(pid, VisualHarvesting.config.menuId, message)
         tes3mp.PlaySpeech(pid, VisualHarvesting.config.success.sound)
         
         tes3mp.ClearInventoryChanges(pid)
         tes3mp.SetInventoryChangesAction(pid, enumerations.inventory.ADD)
-        tes3mp.AddItemChange(pid, plantConfig.ingredient, ingredient_count, -1, -1, "")
+        tes3mp.AddItemChange(pid, ingred, ingredient_count, -1, -1, "")
         tes3mp.SendInventoryChanges(pid)
     end
 end


### PR DESCRIPTION
Plants can now return one of many ingredients; simply provide an
`ingredients` table instead of the normal `ingredient` string and one
is randomly selected at harvest time.

I've also added link to the readme for users that want to extend
VisualHarvesting to support mods like Province Cyrodiil, Skyrim Home
of the Nords, and/or Tamriel Rebuilt.